### PR TITLE
Simplify env vars in deploy script

### DIFF
--- a/nomad/deploy_cluster.sh
+++ b/nomad/deploy_cluster.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
+# Secrets loaded via the 1Password CLI
 echo "Loading credentials..."
-# secrets are loaded via the 1password CLI
 export MASTODON_RDS_USER=$(op item get "<<snip>>" --vault "<<snip>>" --fields label=username)
 export MASTODON_RDS_PASSWORD=$(op item get "<<snip>>" --vault "<<snip>>" --fields label=password)
 export MASTODON_RAILS_SECRET_BASE=$(op item get "<<snip>>" --vault "<<snip>>" --fields label=password)
@@ -14,9 +14,10 @@ export MASTODON_SMTP_PASSWORD=$(op item get "<<snip>>" --vault "<<snip>>" --fiel
 export MASTODON_S3_ACCESS_KEY_ID=$(op item get "<<snip>>" --vault "<<snip>>" --fields label=username)
 export MASTODON_S3_SECRET_ACCESS_KEY=$(op item get "<<snip>>" --vault "<<snip>>" --fields label=password)
 
-export MASTODON_MASTODON_VERSION="v4.0.2"
-export MASTODON_NGINX_VERSION="1.23.2"
-export MASTODON_MASTODON_DOMAIN="<<YOUR_DOMAIN>>"
+# Nomad configuration options
+export MASTODON_VERSION="v4.1.1"
+export MASTODON_NGINX_VERSION="1.23.3"
+export MASTODON_DOMAIN="<<YOUR_DOMAIN>>"
 export MASTODON_RAILS_PORT="3000"
 export MASTODON_REDIS_HOST="<<YOUR_REDIS_URL>>"
 export MASTODON_REDIS_PORT="6379"
@@ -44,44 +45,47 @@ export MASTODON_SESSION_RETENTION_PERIOD="31556952"
 export MASTODON_STREAMING_PORT="4000"
 export MASTODON_MEDIA_RETENTION_DAYS="30"
 
+# Shared Nomad variables
+export NOMAD_VAR_mastodon_domain="${MASTODON_DOMAIN}"
+export NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}"
+export NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}"
+export NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}"
+export NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}"
+export NOMAD_VAR_rds_user="${MASTODON_RDS_USER}"
+export NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}"
+export NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}"
+export NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}"
+export NOMAD_VAR_es_host="${MASTODON_ES_HOST}"
+export NOMAD_VAR_es_port="${MASTODON_ES_PORT}"
+export NOMAD_VAR_es_user="${MASTODON_ES_USER}"
+export NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}"
+export NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}"
+export NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}"
+export NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}"
+export NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}"
+export NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}"
+export NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}"
+export NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}"
+export NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}"
+export NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}"
+export NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}"
+export NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}"
+export NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}"
+export NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}"
+export NOMAD_VAR_rds_user="${MASTODON_RDS_USER}"
+export NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}"
+export NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}"
+export NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}"
+export NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}"
+export NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}"
+export NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}"
+export NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}"
+export NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}"
+export NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}"
+export NOMAD_VAR_media_retention_days="${MASTODON_MEDIA_RETENTION_DAYS}"
+
 echo "Deploying Mastodon migrations..."
-NOMAD_VAR_container_tag="${MASTODON_MASTODON_VERSION}" \
-NOMAD_VAR_mastodon_domain="${MASTODON_MASTODON_DOMAIN}" \
-NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}" \
-NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}" \
-NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}" \
-NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}" \
-NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}" \
-NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}" \
-NOMAD_VAR_es_host="${MASTODON_ES_HOST}" \
-NOMAD_VAR_es_port="${MASTODON_ES_PORT}" \
-NOMAD_VAR_es_user="${MASTODON_ES_USER}" \
-NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}" \
-NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}" \
-NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}" \
-NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}" \
-NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}" \
-NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}" \
-NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}" \
-NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}" \
-NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}" \
-NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}" \
-NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}" \
-NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}" \
-NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}" \
-NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}" \
-NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}" \
-NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}" \
+NOMAD_VAR_container_tag="${MASTODON_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-migrations.nomad
 
 echo "Deploying Mastodon front..."
@@ -89,162 +93,17 @@ NOMAD_VAR_container_tag="${MASTODON_NGINX_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-front.nomad
 
 echo "Deploying Mastodon web..."
-NOMAD_VAR_container_tag="${MASTODON_MASTODON_VERSION}" \
-NOMAD_VAR_mastodon_domain="${MASTODON_MASTODON_DOMAIN}" \
-NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}" \
-NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}" \
-NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}" \
-NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}" \
-NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}" \
-NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}" \
-NOMAD_VAR_es_host="${MASTODON_ES_HOST}" \
-NOMAD_VAR_es_port="${MASTODON_ES_PORT}" \
-NOMAD_VAR_es_user="${MASTODON_ES_USER}" \
-NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}" \
-NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}" \
-NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}" \
-NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}" \
-NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}" \
-NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}" \
-NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}" \
-NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}" \
-NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}" \
-NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}" \
-NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}" \
-NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}" \
-NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}" \
-NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}" \
-NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}" \
-NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}" \
+NOMAD_VAR_container_tag="${MASTODON_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-web.nomad
 
 echo "Deploying Mastodon sidekiq..."
-NOMAD_VAR_container_tag="${MASTODON_MASTODON_VERSION}" \
-NOMAD_VAR_mastodon_domain="${MASTODON_MASTODON_DOMAIN}" \
-NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}" \
-NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}" \
-NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}" \
-NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}" \
-NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}" \
-NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}" \
-NOMAD_VAR_es_host="${MASTODON_ES_HOST}" \
-NOMAD_VAR_es_port="${MASTODON_ES_PORT}" \
-NOMAD_VAR_es_user="${MASTODON_ES_USER}" \
-NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}" \
-NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}" \
-NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}" \
-NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}" \
-NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}" \
-NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}" \
-NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}" \
-NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}" \
-NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}" \
-NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}" \
-NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}" \
-NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}" \
-NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}" \
-NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}" \
-NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}" \
-NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}" \
+NOMAD_VAR_container_tag="${MASTODON_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-sidekiq.nomad
 
 echo "Deploying Mastodon streaming..."
-NOMAD_VAR_container_tag="${MASTODON_MASTODON_VERSION}" \
-NOMAD_VAR_mastodon_domain="${MASTODON_MASTODON_DOMAIN}" \
-NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}" \
-NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}" \
-NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}" \
-NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}" \
-NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}" \
-NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}" \
-NOMAD_VAR_es_host="${MASTODON_ES_HOST}" \
-NOMAD_VAR_es_port="${MASTODON_ES_PORT}" \
-NOMAD_VAR_es_user="${MASTODON_ES_USER}" \
-NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}" \
-NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}" \
-NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}" \
-NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}" \
-NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}" \
-NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}" \
-NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}" \
-NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}" \
-NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}" \
-NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}" \
-NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}" \
-NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}" \
-NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}" \
-NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}" \
-NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}" \
-NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}" \
+NOMAD_VAR_container_tag="${MASTODON_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-streaming.nomad
 
 echo "Deploying Mastodon cleanup cron..."
-NOMAD_VAR_container_tag="${MASTODON_MASTODON_VERSION}" \
-NOMAD_VAR_mastodon_domain="${MASTODON_MASTODON_DOMAIN}" \
-NOMAD_VAR_rails_port="${MASTODON_RAILS_PORT}" \
-NOMAD_VAR_redis_host="${MASTODON_REDIS_HOST}" \
-NOMAD_VAR_redis_port="${MASTODON_REDIS_PORT}" \
-NOMAD_VAR_rds_endpoint="${MASTODON_RDS_ENDPOINT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_name="${MASTODON_RDS_NAME}" \
-NOMAD_VAR_rds_port="${MASTODON_RDS_PORT}" \
-NOMAD_VAR_es_enabled="${MASTODON_ES_ENABLED}" \
-NOMAD_VAR_es_host="${MASTODON_ES_HOST}" \
-NOMAD_VAR_es_port="${MASTODON_ES_PORT}" \
-NOMAD_VAR_es_user="${MASTODON_ES_USER}" \
-NOMAD_VAR_es_password="${MASTODON_ES_PASSWORD}" \
-NOMAD_VAR_smtp_server="${MASTODON_SMTP_SERVER}" \
-NOMAD_VAR_smtp_port="${MASTODON_SMTP_PORT}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_from_address="${MASTODON_SMTP_FROM_ADDRESS}" \
-NOMAD_VAR_s3_enabled="${MASTODON_S3_ENABLED}" \
-NOMAD_VAR_s3_permission="${MASTODON_S3_PERMISSION}" \
-NOMAD_VAR_s3_endpoint="${MASTODON_S3_ENDPOINT}" \
-NOMAD_VAR_s3_bucket_name="${MASTODON_S3_BUCKET_NAME}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_BUCKET_ACCESS_KEY}" \
-NOMAD_VAR_s3_alias_host="${MASTODON_S3_ALIAS_HOST}" \
-NOMAD_VAR_ip_retention_period="${MASTODON_IP_RETENTION_PERIOD}" \
-NOMAD_VAR_session_retention_period="${MASTODON_SESSION_RETENTION_PERIOD}" \
-NOMAD_VAR_streaming_port="${MASTODON_STREAMING_PORT}" \
-NOMAD_VAR_rds_user="${MASTODON_RDS_USER}" \
-NOMAD_VAR_rds_password="${MASTODON_RDS_PASSWORD}" \
-NOMAD_VAR_rails_secret_key_base="${MASTODON_RAILS_SECRET_BASE}" \
-NOMAD_VAR_rails_otp_secret="${MASTODON_RAILS_OTP_SECRET}" \
-NOMAD_VAR_rails_push_private_key="${MASTODON_RAILS_PRIVATE_KEY}" \
-NOMAD_VAR_rails_push_public_key="${MASTODON_RAILS_PUBLIC_KEY}" \
-NOMAD_VAR_smtp_user="${MASTODON_SMTP_USER}" \
-NOMAD_VAR_smtp_password="${MASTODON_SMTP_PASSWORD}" \
-NOMAD_VAR_s3_bucket_access_key="${MASTODON_S3_ACCESS_KEY_ID}" \
-NOMAD_VAR_s3_bucket_secret_key="${MASTODON_S3_SECRET_ACCESS_KEY}" \
-NOMAD_VAR_media_retention_days="${MASTODON_MEDIA_RETENTION_DAYS}" \
+NOMAD_VAR_container_tag="${MASTODON_VERSION}" \
 nomad job run -address=http://localhost:4647 jobs/mastodon-cleanup.nomad

--- a/nomad/jobs/.env.production.template
+++ b/nomad/jobs/.env.production.template
@@ -1,6 +1,4 @@
 /*
-// nomad variables
-
 variable "container_tag" {
   type = string
 }
@@ -137,38 +135,39 @@ variable "streaming_port" {
   type = string
 }
 
-// nomad env block - all these variables appear to be needed in all tasks, so copy from here if editing
-env {
-LOCAL_DOMAIN             = var.mastodon_domain
-REDIS_HOST               = var.redis_host
-REDIS_PORT               = var.redis_port
-DB_HOST                  = var.rds_endpoint
-DB_USER                  = var.rds_user
-DB_NAME                  = var.rds_name
-DB_PASS                  = var.rds_password
-DB_PORT                  = var.rds_port
-ES_ENABLED               = var.es_enabled
-ES_HOST                  = var.es_host
-ES_PORT                  = var.es_port
-ES_USER                  = var.es_user
-ES_PASS                  = var.es_password
-SECRET_KEY_BASE          = var.rails_secret_key_base
-OTP_SECRET               = var.rails_otp_secret
-VAPID_PRIVATE_KEY        = var.rails_push_private_key
-VAPID_PUBLIC_KEY         = var.rails_push_public_key
-SMTP_SERVER              = var.smtp_server
-SMTP_PORT                = var.smtp_port
-SMTP_LOGIN               = var.smtp_user
-SMTP_PASSWORD            = var.smtp_password
-SMTP_FROM_ADDRESS        = var.smtp_from_address
-S3_ENABLED               = var.s3_enabled
-S3_ENDPOINT              = var.s3_endpoint
-S3_BUCKET                = var.s3_bucket_name
-S3_PERMISSION            = var.s3_permission
-AWS_ACCESS_KEY_ID        = var.s3_bucket_access_key
-AWS_SECRET_ACCESS_KEY    = var.s3_bucket_secret_key
-S3_ALIAS_HOST            = var.s3_alias_host
-IP_RETENTION_PERIOD      = var.ip_retention_period
-SESSION_RETENTION_PERIOD = var.session_retention_period
-}
+
+  note: all these variables appear to be needed in all tasks, so copy from here if editing
+  env {
+    LOCAL_DOMAIN             = var.mastodon_domain
+    REDIS_HOST               = var.redis_host
+    REDIS_PORT               = var.redis_port
+    DB_HOST                  = var.rds_endpoint
+    DB_USER                  = var.rds_user
+    DB_NAME                  = var.rds_name
+    DB_PASS                  = var.rds_password
+    DB_PORT                  = var.rds_port
+    ES_ENABLED               = var.es_enabled
+    ES_HOST                  = var.es_host
+    ES_PORT                  = var.es_port
+    ES_USER                  = var.es_user
+    ES_PASS                  = var.es_password
+    SECRET_KEY_BASE          = var.rails_secret_key_base
+    OTP_SECRET               = var.rails_otp_secret
+    VAPID_PRIVATE_KEY        = var.rails_push_private_key
+    VAPID_PUBLIC_KEY         = var.rails_push_public_key
+    SMTP_SERVER              = var.smtp_server
+    SMTP_PORT                = var.smtp_port
+    SMTP_LOGIN               = var.smtp_user
+    SMTP_PASSWORD            = var.smtp_password
+    SMTP_FROM_ADDRESS        = var.smtp_from_address
+    S3_ENABLED               = var.s3_enabled
+    S3_ENDPOINT              = var.s3_endpoint
+    S3_BUCKET                = var.s3_bucket_name
+    S3_PERMISSION            = var.s3_permission
+    AWS_ACCESS_KEY_ID        = var.s3_bucket_access_key
+    AWS_SECRET_ACCESS_KEY    = var.s3_bucket_secret_key
+    S3_ALIAS_HOST            = var.s3_alias_host
+    IP_RETENTION_PERIOD      = var.ip_retention_period
+    SESSION_RETENTION_PERIOD = var.session_retention_period
+  }
 */

--- a/nomad/jobs/mastodon-cleanup.nomad
+++ b/nomad/jobs/mastodon-cleanup.nomad
@@ -164,7 +164,7 @@ job "mastodon-cleanup" {
         args = [
           "bash",
           "-c",
-          "tootctl media remove --days ${var.media_retention_days} && tootctl preview_cards remove --days ${var.media_retention_days}"
+          "tootctl media remove --days ${var.media_retention_days} && tootctl media remove --days ${var.media_retention_days} --prune-profiles && tootctl preview_cards remove --days ${var.media_retention_days}"
         ]
       }
 


### PR DESCRIPTION
* Refactors `deploy_cluster.sh` to pull shared Nomad variables in to one group
* Updates Mastodon and nginx to latest stable versions
* Adds `--prune-profiles` pass to cleanup script